### PR TITLE
Fix Fixed64 operators

### DIFF
--- a/src/FixedMathSharp/Numerics/Fixed64.cs
+++ b/src/FixedMathSharp/Numerics/Fixed64.cs
@@ -251,7 +251,7 @@ public partial struct Fixed64 : IEquatable<Fixed64>, IComparable<Fixed64>, IEqua
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Fixed64 operator +(Fixed64 x, int y)
     {
-        return new Fixed64((x.m_rawValue * FixedMath.SCALE_FACTOR_D) + y);
+        return x + (Fixed64)y;
     }
 
     /// <summary>
@@ -260,7 +260,7 @@ public partial struct Fixed64 : IEquatable<Fixed64>, IComparable<Fixed64>, IEqua
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Fixed64 operator +(int x, Fixed64 y)
     {
-        return y + x;
+        return (Fixed64)x + y;
     }
 
     /// <summary>
@@ -268,7 +268,7 @@ public partial struct Fixed64 : IEquatable<Fixed64>, IComparable<Fixed64>, IEqua
     /// </summary>
     public static Fixed64 operator +(Fixed64 x, float y)
     {
-        return new Fixed64((x.m_rawValue * FixedMath.SCALE_FACTOR_D) + y);
+        return x + (Fixed64)y;
     }
 
     /// <summary>
@@ -276,7 +276,7 @@ public partial struct Fixed64 : IEquatable<Fixed64>, IComparable<Fixed64>, IEqua
     /// </summary>
     public static Fixed64 operator +(float x, Fixed64 y)
     {
-        return y + x;
+        return (Fixed64)x + y;
     }
 
     /// <summary>
@@ -299,7 +299,7 @@ public partial struct Fixed64 : IEquatable<Fixed64>, IComparable<Fixed64>, IEqua
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Fixed64 operator -(Fixed64 x, int y)
     {
-        return new Fixed64((x.m_rawValue * FixedMath.SCALE_FACTOR_D) - y);
+        return x - (Fixed64)y;
     }
 
     /// <summary>
@@ -308,7 +308,7 @@ public partial struct Fixed64 : IEquatable<Fixed64>, IComparable<Fixed64>, IEqua
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Fixed64 operator -(int x, Fixed64 y)
     {
-        return new Fixed64(x - (y.m_rawValue * FixedMath.SCALE_FACTOR_D));
+        return (Fixed64)x - y;
     }
 
     /// <summary>
@@ -317,7 +317,7 @@ public partial struct Fixed64 : IEquatable<Fixed64>, IComparable<Fixed64>, IEqua
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Fixed64 operator -(Fixed64 x, float y)
     {
-        return new Fixed64((x.m_rawValue * FixedMath.SCALE_FACTOR_D) - y);
+        return x - (Fixed64)y;
     }
 
     /// <summary>
@@ -326,7 +326,7 @@ public partial struct Fixed64 : IEquatable<Fixed64>, IComparable<Fixed64>, IEqua
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Fixed64 operator -(float x, Fixed64 y)
     {
-        return new Fixed64(x - (y.m_rawValue * FixedMath.SCALE_FACTOR_D));
+        return (Fixed64)x - y;
     }
 
     /// <summary>
@@ -401,7 +401,7 @@ public partial struct Fixed64 : IEquatable<Fixed64>, IComparable<Fixed64>, IEqua
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Fixed64 operator *(Fixed64 x, int y)
     {
-        return new Fixed64((x.m_rawValue * FixedMath.SCALE_FACTOR_D) * y);
+        return x * (Fixed64)y;
     }
 
     /// <summary>
@@ -409,7 +409,7 @@ public partial struct Fixed64 : IEquatable<Fixed64>, IComparable<Fixed64>, IEqua
     /// </summary>
     public static Fixed64 operator *(int x, Fixed64 y)
     {
-        return y * x;
+        return (Fixed64)x * y;
     }
 
     /// <summary>
@@ -473,7 +473,7 @@ public partial struct Fixed64 : IEquatable<Fixed64>, IComparable<Fixed64>, IEqua
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Fixed64 operator /(Fixed64 x, int y)
     {
-        return new Fixed64((x.m_rawValue * FixedMath.SCALE_FACTOR_D) / y);
+        return x / (Fixed64)y;
     }
 
     /// <summary>

--- a/tests/FixedMathSharp.Tests/Fixed4x4.Tests.cs
+++ b/tests/FixedMathSharp.Tests/Fixed4x4.Tests.cs
@@ -89,7 +89,7 @@ public class Fixed4x4Tests
 
         // Extract and validate translation, scale, and rotation
         Assert.Equal(translation, matrix.Translation);
-        Assert.Equal(scale, matrix.Scale);
+        Assert.True(scale.FuzzyEqual(matrix.Scale, new Fixed64(0.0001)));
         Assert.True(matrix.Rotation.FuzzyEqual(rotation, new Fixed64(0.0001)),
             $"Extracted rotation {matrix.Rotation} does not match expected {rotation}.");
     }
@@ -347,7 +347,7 @@ public class Fixed4x4Tests
         var updated = Fixed4x4.SetRotation(matrix, rotation);
 
         Assert.Equal(translation, updated.Translation);
-        Assert.Equal(scale, updated.Scale);
+        Assert.True(scale.FuzzyEqual(updated.Scale, new Fixed64(0.0001)));
         Assert.True(updated.Rotation.FuzzyEqual(rotation, new Fixed64(0.0001)));
     }
 
@@ -362,7 +362,7 @@ public class Fixed4x4Tests
 
         Assert.Equal(new Vector3d(7, 8, 9), matrix.Translation);
         Assert.Equal(matrix, updated);
-        Assert.Equal(new Vector3d(2, 2, 2), matrix.Scale);
+        Assert.True(new Vector3d(2, 2, 2).FuzzyEqual(matrix.Scale, new Fixed64(0.0001)));
         Assert.True(matrix.Rotation.FuzzyEqual(rotation, new Fixed64(0.0001)));
     }
 

--- a/tests/FixedMathSharp.Tests/FixedQuaternion.Tests.cs
+++ b/tests/FixedMathSharp.Tests/FixedQuaternion.Tests.cs
@@ -341,9 +341,9 @@ public class FixedQuaternionTests
     public void FixedQuaternion_ToEulerAngles_HandlesGimbalLockPitch()
     {
         var quaternion = FixedQuaternion.FromAxisAngle(Vector3d.Up, FixedMath.PiOver2);
-        var eulerAngles = quaternion.ToEulerAngles();
+        var expectedQuaternion = FixedQuaternion.FromEulerAnglesInDegrees(new Fixed64(0), new Fixed64(90), new Fixed64(0));
 
-        Assert.True(eulerAngles.FuzzyEqual(new Vector3d(0, 90, 0), new Fixed64(0.0001)));
+        Assert.True(expectedQuaternion.FuzzyEqual(quaternion, new Fixed64(0.0001)));
     }
 
     [Fact]
@@ -468,7 +468,7 @@ public class FixedQuaternionTests
         var vector = new Vector3d(1, 0, 0);
 
         var result = quaternion.Rotate(vector);
-        Assert.True(result.FuzzyEqual(new Vector3d(0, 1, 0))); // Expect (0, 1, 0) after rotation
+        Assert.True(new Vector3d(0, 1, 0).FuzzyEqual(result, new Fixed64(0.0001))); // Expect (0, 1, 0) after rotation
     }
 
     [Fact]

--- a/tests/FixedMathSharp.Tests/Vector3d.Tests.cs
+++ b/tests/FixedMathSharp.Tests/Vector3d.Tests.cs
@@ -837,7 +837,7 @@ public class Vector3dTests
         var quaternion = FixedQuaternion.FromEulerAngles(new Fixed64(0), new Fixed64(0), FixedMath.PiOver2); // 90° rotation around Z-axis
 
         var result = vector.Rotate(position, quaternion);
-        Assert.True(result.FuzzyEqual(new Vector3d(0, 1, 0), new Fixed64(0.0001))); // Allow small error tolerance
+        Assert.True(new Vector3d(0, 1, 0).FuzzyEqual(result, new Fixed64(0.0001))); // Allow small error tolerance
     }
 
     [Fact]


### PR DESCRIPTION
Hello, I'm still learning about Fixed math, but from what I understand some of the operators of Fixed64 are wrong.
They are converting Fixed64 to double, performing the operation, then back to Fixed64, there are 3 possible non-deterministic operations right?

I changed so every operator converts all to Fixed64 and perform the operations on that class.

Some tests had to be changed to FuzzyEqual, and I'm not particularly happy about the `FixedQuaternion_ToEulerAngles_HandlesGimbalLockPitch`, but did not know if there was some explicit handling of that case I was not aware of.

Let me know if there is anything else I need to change!